### PR TITLE
Remove usage of JSON.pm

### DIFF
--- a/bin/zild-render-template
+++ b/bin/zild-render-template
@@ -5,14 +5,12 @@ use Cwd;
 use File::Share;
 use Hash::Merge 'merge';
 use IO::All;
-use JSON;
 use Template::Toolkit::Simple;
 use Zilla::Dist;
 
-my ($template, $target, $json) = @ARGV;
+my ($template, $target) = @ARGV;
 
 $target ||= $template;
-$json ||= '{}';
 
 if (-e "pkg/$template") {
   my $text = io->file("pkg/$template")->all;


### PR DESCRIPTION
It was never used, and it is no longer listed as a dependency
since 28fb83e (version 2.1.7)

Fixes #58